### PR TITLE
add DS3231 submodule to bundle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -70,3 +70,6 @@
 [submodule "libraries/drivers/sdcard"]
 	path = libraries/drivers/sdcard
 	url = https://github.com/adafruit/Adafruit_CircuitPython_SD.git
+[submodule "libraries/drivers/ds3231"]
+	path = libraries/drivers/ds3231
+	url = https://github.com/adafruit/Adafruit_CircuitPython_DS3231.git


### PR DESCRIPTION
OK i think I have added the ds3231 submodule to the circuitpython_bundle.  If you think this is the wrong time for this, then just ignore it and i will do again at some future point.  if you like it, i would like to work on the adafruit_circuitpython_max7219 git project.  i that something I can do as well?