### PR TITLE
Enable overwriting artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ deploy:
   file_glob: true
   file: bundles/*
   skip_cleanup: true
+  overwrite: true
   on:
     tags: true
 


### PR DESCRIPTION
This lets us release new zips based on a newer circuitpython-build-tools package.

This is needed to fix #55 