### PR TITLE
Adding AdafruitIO to Bundle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -412,3 +412,6 @@
 [submodule "libraries/helpers/logging"]
 	path = libraries/helpers/logging
 	url = https://github.com/adafruit/Adafruit_CircuitPython_Logger
+[submodule "libraries/helpers/adafruitio"]
+	path = libraries/helpers/adafruitio
+	url = https://github.com/adafruit/Adafruit_CircuitPython_AdafruitIO.git


### PR DESCRIPTION
MakerMelissa added Adafruit IO to `drivers.rst` in: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/pull/138

The most recent CircuitPython_Bundle does not contain `adafruitio`, this PR aims to add the library to `helpers`