### PR TITLE
add DymoScale library to bundle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -427,3 +427,6 @@
 [submodule "libraries/drivers/veml7700"]
 	path = libraries/drivers/veml7700
 	url = https://github.com/adafruit/Adafruit_CircuitPython_VEML7700.git
+[submodule "libraries/drivers/dymoscale"]
+	path = libraries/drivers/dymoscale
+	url = https://github.com/adafruit/Adafruit_CircuitPython_DymoScale.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -256,3 +256,4 @@ Miscellaneous
     Trellis 4x4 Keypad <https://circuitpython.readthedocs.io/projects/trellis/en/latest/>
     VC0706 TTL Camera <https://circuitpython.readthedocs.io/projects/vc0706/en/latest/>
     VS1053 Audio Codec <https://circuitpython.readthedocs.io/projects/vs1053/en/latest/>
+    Dymo Scale <https://circuitpython.readthedocs.io/projects/dymoscale/en/latest/>


### PR DESCRIPTION
Adding DymoScale library to bundle and docs 
https://github.com/adafruit/Adafruit_CircuitPython_DymoScale