### PR TITLE
Update Travis To Use New circuitpython-build-tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,5 @@ deploy:
     tags: true
 
 script:
-- circuitpython-build-bundles --filename_prefix adafruit-circuitpython-bundle --library_location libraries --library_depth 2
+- circuitpython-build-bundles --filename_prefix adafruit-circuitpython-bundle --library_location libraries --library_depth 2 --package_folder_prefix adafruit_
 - cd docs && sphinx-build -E -W -b html . _build/html && cd ..


### PR DESCRIPTION
New release of `circuitpython-build-tools` now uses a `package_folder_prefix` command line argument to use to identify packaged library folders. 