### PR TITLE
Add Nunchuk

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -493,3 +493,6 @@
 [submodule "libraries/helpers/minimqtt"]
 	path = libraries/helpers/minimqtt
 	url = https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT.git
+[submodule "libraries/drivers/nunchuk"]
+	path = libraries/drivers/nunchuk
+	url = https://github.com/adafruit/Adafruit_CircuitPython_Nunchuk.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -278,3 +278,4 @@ Miscellaneous
     VC0706 TTL Camera <https://circuitpython.readthedocs.io/projects/vc0706/en/latest/>
     VS1053 Audio Codec <https://circuitpython.readthedocs.io/projects/vs1053/en/latest/>
     Dymo Scale <https://circuitpython.readthedocs.io/projects/dymoscale/en/latest/>
+    Nunchuk <https://circuitpython.readthedocs.io/projects/nunchuk/en/latest/>


### PR DESCRIPTION
Add CircuitPython driver for Wii Remote Nunchuk.

Submitting here instead of Community bundle as discussed here:
https://github.com/adafruit/CircuitPython_Community_Bundle/pull/24