### PR TITLE
Append Missing '.git' To Submodule URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -438,7 +438,7 @@
 	url = https://github.com/adafruit/Adafruit_CircuitPython_IterTools.git
 [submodule "libraries/helpers/lifx"]
 	path = libraries/helpers/lifx
-	url = https://github.com/adafruit/Adafruit_CircuitPython_LIFX
+	url = https://github.com/adafruit/Adafruit_CircuitPython_LIFX.git
 [submodule "libraries/helpers/hue"]
 	path = libraries/helpers/hue
 	url = https://github.com/adafruit/Adafruit_CircuitPython_Hue.git
@@ -480,10 +480,10 @@
 	url = https://github.com/adafruit/Adafruit_CircuitPython_RGBLED.git
 [submodule "libraries/helpers/pyoa"]
 	path = libraries/helpers/pyoa
-	url = https://github.com/adafruit/Adafruit_CircuitPython_PYOA
+	url = https://github.com/adafruit/Adafruit_CircuitPython_PYOA.git
 [submodule "libraries/helpers/turtle"]
 	path = libraries/helpers/turtle
-	url = https://github.com/adafruit/Adafruit_CircuitPython_turtle
+	url = https://github.com/adafruit/Adafruit_CircuitPython_turtle.git
 [submodule "libraries/drivers/vcnl4040"]
 	path = libraries/drivers/vcnl4040
 	url = https://github.com/adafruit/Adafruit_CircuitPython_VCNL4040.git


### PR DESCRIPTION
As discovered in [circup \#9](https://github.com/ntoll/circup/issues/9#issuecomment-527886758), a few of the submodules in `.gitmodules` did not have `.git` appended to the remote URL.

This really only affects `VERSIONS.txt` in the bundle. We can also handle this `circuitpython-build-tools`, in the event that it occurs again. Just need to add another conditional here: https://github.com/adafruit/circuitpython-build-tools/blob/master/circuitpython_build_tools/scripts/build_bundles.py#L96