### PR TITLE
Add CircuitPython_ATECC library to bundle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -556,3 +556,6 @@
 [submodule "libraries/drivers/msa301"]
 	path = libraries/drivers/msa301
 	url = https://github.com/adafruit/Adafruit_CircuitPython_MSA301.git
+[submodule "libraries/drivers/atecc"]
+	path = libraries/drivers/atecc
+	url = https://github.com/adafruit/Adafruit_CircuitPython_ATECC.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -378,6 +378,7 @@ Miscellaneous
 .. toctree::
 
     74HC595 Shift Register <https://circuitpython.readthedocs.io/projects/74hc595/en/latest/>
+    ATECCx08 Cryptographic Co-Processor <https://circuitpython.readthedocs.io/projects/atecc/en/latest/>
     AMG88xx Grid-Eye IR Camera <https://circuitpython.readthedocs.io/projects/amg88xx/en/latest/>
     BD3491FS Audio Processor  <https://circuitpython.readthedocs.io/projects/bd3491fs/en/latest/>
     CAP1188 8-Key Capacitive Touch <https://circuitpython.readthedocs.io/projects/cap1188/en/latest/>


### PR DESCRIPTION
Adding [Adafruit_Atecc](https://github.com/adafruit/Adafruit_CircuitPython_ATECC), a CircuitPython Driver for Microchip's ATECCx08 cryptographic co-processors with secure hardware-based key storage. 