### PR TITLE
Add AWS IoT to CircuitPython Bundle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -559,3 +559,6 @@
 [submodule "libraries/drivers/atecc"]
 	path = libraries/drivers/atecc
 	url = https://github.com/adafruit/Adafruit_CircuitPython_ATECC.git
+[submodule "libraries/helpers/AWS_IOT"]
+	path = libraries/helpers/AWS_IOT
+	url = https://github.com/adafruit/Adafruit_CircuitPython_AWS_IOT.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -87,6 +87,7 @@ Helpers for connecting with hosted and self-hosted internet-of-things web servic
 .. toctree::
 
     Adafruit IO <https://circuitpython.readthedocs.io/projects/adafruitio/en/latest/>
+    Amazon AWS IoT <https://circuitpython.readthedocs.io/projects/aws_iot/en/latest/>
     Azure IoT <https://circuitpython.readthedocs.io/projects/azureiot/en/latest/>
     Google Cloud IoT Core <https://circuitpython.readthedocs.io/projects/gc_iot_core/en/latest/>
     LIFX Lights <https://circuitpython.readthedocs.io/projects/lifx/en/latest/>


### PR DESCRIPTION
Adding the Amazon AWS IoT MQTT Client for CircuitPython (https://github.com/adafruit/Adafruit_CircuitPython_AWS_IOT)