### PR TITLE
Update Logging Submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -414,7 +414,7 @@
 	url = https://github.com/adafruit/Adafruit_CircuitPython_INA260.git
 [submodule "libraries/helpers/logging"]
 	path = libraries/helpers/logging
-	url = https://github.com/adafruit/Adafruit_CircuitPython_Logger.git
+	url = https://github.com/adafruit/Adafruit_CircuitPython_Logging.git
 [submodule "libraries/helpers/adafruitio"]
 	path = libraries/helpers/adafruitio
 	url = https://github.com/adafruit/Adafruit_CircuitPython_AdafruitIO.git


### PR DESCRIPTION
The Logging repo name was changed from `Adafruit_CircuitPython_Logger` to `Adafruit_CircuitPython_Logging`. The bundle's `.gitmodules` wasn't updated, and adabot was flagging the library as not being in the bundle due to the mismatch.

GitHub apparently redirects from the old URL to the new one; at least in a browser.