### PR TITLE
renamed lsm303agr_mag to it's proper name lis2mdl

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -565,9 +565,6 @@
 [submodule "libraries/drivers/lsm303-accel"]
 	path = libraries/drivers/lsm303-accel
 	url = https://github.com/adafruit/Adafruit_CircuitPython_LSM303_Accel.git
-[submodule "libraries/drivers/lsm303agr-mag"]
-	path = libraries/drivers/lsm303agr-mag
-	url = https://github.com/adafruit/Adafruit_CircuitPython_LSM303AGR_Mag.git
 [submodule "libraries/drivers/lsm303dlh-mag"]
 	path = libraries/drivers/lsm303dlh-mag
 	url = https://github.com/adafruit/Adafruit_CircuitPython_LSM303DLH_Mag.git
@@ -613,3 +610,6 @@
 [submodule "libraries/helpers/display_notification"]
 	path = libraries/helpers/display_notification
 	url = https://github.com/adafruit/Adafruit_CircuitPython_Display_Notification.git
+[submodule "libraries/drivers/lis2mdl"]
+	path = libraries/drivers/lis2mdl
+	url = https://github.com/adafruit/Adafruit_CircuitPython_LIS2MDL.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -262,10 +262,10 @@ Motion relating sensing including ``acceleration``, ``magnetic``, ``gyro``, and 
     GPS Global Position <https://circuitpython.readthedocs.io/projects/gps/en/latest/>
     ISM20649 Wide-rage 6-DoF Accelerometer and Gyro <https://circuitpython.readthedocs.io/projects/ism20649/en/latest/>
     L3GD20 3-Axis Gyroscope <https://circuitpython.readthedocs.io/projects/l3gd20/en/latest/>
+    LIS2MDL 3-Axis Magnetometer <https://circuitpython.readthedocs.io/projects/lis2mdl/en/latest/>
     LIS3DH Accelerometer <https://circuitpython.readthedocs.io/projects/lis3dh/en/latest/>
     LSM303 Accelerometer and Magnetometer <https://circuitpython.readthedocs.io/projects/lsm303/en/latest/>
     LSM303 Accelerometer Only<https://circuitpython.readthedocs.io/projects/lsm303-accel/en/latest/>
-    LSM303AGR Magnetometer Only<https://circuitpython.readthedocs.io/projects/lsm303agr-mag/en/latest/>
     LSM303DLH Magnetometer Only<https://circuitpython.readthedocs.io/projects/lsm303dlh-mag/en/latest/>
     LSMDSOX Accelerometer, Gyroscope and Temperature <https://circuitpython.readthedocs.io/projects/lsm6dsox/en/latest/>
     LSM9DS0 Accelerometer, Magnetometer, Gyroscope and Temperature <https://circuitpython.readthedocs.io/projects/lsm9ds0/en/latest/>


### PR DESCRIPTION
We've renamed the LSM303AGR_Mag library to have the name of the actual mag sensor; We'll likely do the same for the accelerometer if we can identify it.