### PR TITLE
Re-add gettext To Actions Workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
         submodules: true
     - name: Install deps
       run: |
+        sudo apt-get install gettext
         pip install -r requirements.txt
     - name: Library version
       run: git describe --dirty --always --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
         submodules: true
     - name: Install deps
       run: |
+        sudo apt-get install gettext
         pip install -r requirements.txt
     - name: Build assets
       run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location libraries --library_depth 2


### PR DESCRIPTION
During my review of #217, I requested removal of `apt-get install gettext`. I shouldn't have, since it is required to build `mpy-cross` in `circuitpython-build-tools`. 🤦‍♂ 