### PR TITLE
Add Wiznet5k to bundle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -657,4 +657,4 @@
 	url = https://github.com/adafruit/Adafruit_CircuitPython_ProgressBar.git
 [submodule "libraries/drivers/wiznet5k"]
 	path = libraries/drivers/wiznet5k
-	url = git@github.com:adafruit/Adafruit_CircuitPython_Wiznet5k.git
+	url = https://github.com/adafruit/Adafruit_CircuitPython_Wiznet5k.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -655,3 +655,6 @@
 [submodule "libraries/helpers/progressbar"]
 	path = libraries/helpers/progressbar
 	url = https://github.com/adafruit/Adafruit_CircuitPython_ProgressBar.git
+[submodule "libraries/drivers/wiznet5k"]
+	path = libraries/drivers/wiznet5k
+	url = git@github.com:adafruit/Adafruit_CircuitPython_Wiznet5k.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -378,6 +378,15 @@ These sensors measure the ``distance`` to another object and may also measure li
     VL6180x 5 - 100 mm <https://circuitpython.readthedocs.io/projects/vl6180x/en/latest/>
     VL53L0x ~30 - 1000 mm <https://circuitpython.readthedocs.io/projects/vl53l0x/en/latest/>
 
+Ethernet
+----------
+
+These chips communicate over the Ethernet networking standard.
+
+.. toctree::
+
+    Wiznet 5k Ethernet modules over SPI <https://circuitpython.readthedocs.io/projects/wiznet5k/en/latest/>
+
 Radio
 --------
 

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -378,15 +378,6 @@ These sensors measure the ``distance`` to another object and may also measure li
     VL6180x 5 - 100 mm <https://circuitpython.readthedocs.io/projects/vl6180x/en/latest/>
     VL53L0x ~30 - 1000 mm <https://circuitpython.readthedocs.io/projects/vl53l0x/en/latest/>
 
-Ethernet
-----------
-
-These chips communicate over the Ethernet networking standard.
-
-.. toctree::
-
-    Wiznet 5k Ethernet modules over SPI <https://circuitpython.readthedocs.io/projects/wiznet5k/en/latest/>
-
 Radio
 --------
 
@@ -457,3 +448,4 @@ Miscellaneous
     VS1053 Audio Codec <https://circuitpython.readthedocs.io/projects/vs1053/en/latest/>
     Dymo Scale <https://circuitpython.readthedocs.io/projects/dymoscale/en/latest/>
     Nunchuk <https://circuitpython.readthedocs.io/projects/nunchuk/en/latest/>
+    Wiznet5k Ethernet Module <https://circuitpython.readthedocs.io/projects/wiznet5k/en/latest/>


### PR DESCRIPTION
Adding [Wiznet5k library](https://github.com/adafruit/Adafruit_CircuitPython_Wiznet5k/) to bundle.

@kattni  I did not see a section within `drivers.rst` appropriate for ethernet modules so I added one. People may add modules which support different vendors down the line. Please let me know if I need to change anything else.