### PR TITLE
Remove 'www.' From MCP4728 Submodule Clone URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -600,7 +600,7 @@
 	url = https://github.com/adafruit/Adafruit_CircuitPython_LSM6DS.git
 [submodule "libraries/drivers/mcp4728"]
 	path = libraries/drivers/mcp4728
-	url = https://www.github.com/adafruit/Adafruit_CircuitPython_MCP4728.git
+	url = https://github.com/adafruit/Adafruit_CircuitPython_MCP4728.git
 [submodule "libraries/helpers/ble_apple_notification_center"]
 	path = libraries/helpers/ble_apple_notification_center
 	url = https://github.com/adafruit/Adafruit_CircuitPython_BLE_Apple_Notification_Center.git


### PR DESCRIPTION
Fixes https://github.com/adafruit/adabot/issues/145