### PR TITLE
adding AS7341

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -703,3 +703,6 @@
 [submodule "libraries/drivers/bh1750"]
 	path = libraries/drivers/bh1750
 	url = https://github.com/adafruit/Adafruit_CircuitPython_BH1750.git
+[submodule "libraries/drivers/as7341"]
+	path = libraries/drivers/as7341
+	url = https://github.com/adafruit/Adafruit_CircuitPython_AS7341.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -366,6 +366,7 @@ These sensors detect light related attributes such as ``color``, ``light`` (unit
 
     APDS9960 Proximity, Light, RGB, and Gesture <https://circuitpython.readthedocs.io/projects/apds9960/en/latest/>
     AS726x Color Spectrum Sensor <https://circuitpython.readthedocs.io/projects/as726x/en/latest/>
+    AS7341 11-Channel Multi-Spectral Digital Sensor <https://circuitpython.readthedocs.io/projects/as7341/en/latest/>
     BH1750 Ambient Light <https://circuitpython.readthedocs.io/projects/bh1750/en/latest/>
     TCS34725 Color Sensor <https://circuitpython.readthedocs.io/projects/tcs34725/en/latest/>
     TSL2561 Light Sensor <https://circuitpython.readthedocs.io/projects/tsl2561/en/latest/>


### PR DESCRIPTION
My old TV had channels A-H. This sensor has Channels F1-F8, Clear, Dark, NIR, and FD. Let's add it.