### PR TITLE
add airlift helper

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -718,3 +718,6 @@
 [submodule "libraries/helpers/pixel_framebuf"]
 	path = libraries/helpers/pixel_framebuf
 	url = https://github.com/adafruit/Adafruit_CircuitPython_Pixel_Framebuf.git
+[submodule "libraries/helpers/airlift"]
+	path = libraries/helpers/airlift
+	url = https://github.com/adafruit/Adafruit_CircuitPython_AirLift.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -405,6 +405,7 @@ These chips communicate to others over radio.
 .. toctree::
 
     Adafruit Bluefruit LE SPI Friend <https://circuitpython.readthedocs.io/projects/bluefruitspi/en/latest/>
+    AirLift Co-Processor Manager <https://circuitpython.readthedocs.io/projects/airlift/en/latest/>
     ESP WiFi Co-Processor using AT Commands <https://circuitpython.readthedocs.io/projects/esp-atcontrol/en/latest/>
     ESP32 WiFi Co-Processor over SPI <https://circuitpython.readthedocs.io/projects/esp32spi/en/latest/>
     RFM9x LoRa <https://circuitpython.readthedocs.io/projects/rfm9x/en/latest/>


### PR DESCRIPTION
Helps manage AirLift co-processors, for both wifi and BLE use. Currently supports ESP32.