### PR TITLE
adding tla202x

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -724,3 +724,6 @@
 [submodule "libraries/helpers/airlift"]
 	path = libraries/helpers/airlift
 	url = https://github.com/adafruit/Adafruit_CircuitPython_AirLift.git
+[submodule "libraries/drivers/tla202x"]
+	path = libraries/drivers/tla202x
+	url = https://github.com/adafruit/Adafruit_CircuitPython_TLA202X.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -433,6 +433,7 @@ These provide functionality similar to ``analogio``, ``digitalio``, ``pulseio``,
     PCA9685 16 x 12-bit PWM Driver <https://circuitpython.readthedocs.io/projects/pca9685/en/latest/>
     PCF8591 ADC + DAC Combo <https://circuitpython.readthedocs.io/projects/pcf8591/en/latest/>
     TCA9548 I2C Multiplexer <https://circuitpython.readthedocs.io/projects/tca9548a/en/latest/>
+    TLA202X 12-bit I2C DAC <https://circuitpython.readthedocs.io/projects/tla202x/en/latest/>
     TLC5947 24 x 12-bit PWM Driver <https://circuitpython.readthedocs.io/projects/tlc5947/en/latest/>
     TLC59711 12 x 16-bit PWM Driver <https://circuitpython.readthedocs.io/projects/tlc59711/en/latest/>
 


### PR DESCRIPTION
Faster than a slower ADC!
More powerful than a 8-bit single channel ADC
Able to measure voltages in a single bound!
Look, up in the sky!
It's a bird!
It's a plane!
It's the TLA202x library!
