### PR TITLE
Add simplemath

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -769,3 +769,6 @@
 [submodule "libraries/helpers/oauth_2"]
 	path = libraries/helpers/oauth_2
 	url = https://github.com/adafruit/Adafruit_CircuitPython_OAuth2.git
+[submodule "libraries/helpers/simplemath"]
+	path = libraries/helpers/simplemath
+	url = https://github.com/adafruit/Adafruit_CircuitPython_SimpleMath.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -196,6 +196,7 @@ Miscellaneous Helpers
     OneWire <https://circuitpython.readthedocs.io/projects/onewire/en/latest/>
     SD Card <https://circuitpython.readthedocs.io/projects/sd/en/latest/>
     SimpleIO <https://circuitpython.readthedocs.io/projects/simpleio/en/latest/>
+    SimpleMath <https://circuitpython.readthedocs.io/projects/simplemath/en/latest/>
     USB Human Interface Device (Keyboard and Mouse) <https://circuitpython.readthedocs.io/projects/hid/en/latest/>
     Test Repo <https://circuitpython.readthedocs.io/projects/testrepo/en/latest/>
 


### PR DESCRIPTION
`adafruit_simplemath` provides `map_range()`, which is the main use for `simpleio`, but does not included other `simpleio` functionality. In addition to `map_range()`, it also provides `constrain()`. It is meant to be a substitute for most uses of `simpleio`.