### PR TITLE
Add workflow to build folder images for examples

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,0 +1,51 @@
+name: Generate folder images
+
+on:
+  schedule:
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+  push:
+    branches: [master]
+
+concurrency:
+  group: folder-images
+  cancel-in-progress: true
+
+jobs:
+  update-images:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+
+    - uses: actions/checkout@v2.2.0
+
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+
+    - name: Checkout screenshot maker
+      run: git clone --depth=1 https://github.com/circuitpython/CircuitPython_Library_Screenshot_Maker
+
+    - name: Install dependencies
+      run: pip install -r CircuitPython_Library_Screenshot_Maker/requirements.txt
+
+    - name: Generate images
+      run: |
+        find libraries -pattern "libraries/*/examples/*.py" -exec python3 CircuitPython_Library_Screenshot_Maker/create_requirement_images_bundle.py {} +
+
+    - name: Commit updates
+      run: |
+        cd generated_images
+        git config --global user.name "${GITHUB_ACTOR} (github actions cron)"
+        git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+        git config --global init.defaultBranch main
+        git init
+        for i in *.png; do echo "<a href=\"$i\">$i</a><br>"; done > index.html
+        git add *.png index.html
+        git remote add origin https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+        if git commit -m"update images"; then git push -f origin HEAD:folder-images; fi
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,8 @@ build/*
 *zip
 .env
 bundles
+CircuitPython_Library_Screenshot_Maker/
 .DS_Store
+generated_images/
+latest_bundle_data.json
+latest_bundle_tag.json


### PR DESCRIPTION
.. this will not work until https://github.com/circuitpython/CircuitPython_Library_Screenshot_Maker/pull/5 is merged.  However, as the actions are only run on pushes to the main branch (not for pull requests) this will not show up as a red check-mark for this PR's actions.