### PR TITLE
images: don't update based on pushes to master

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -4,8 +4,6 @@ on:
   schedule:
     - cron: '0 10 * * *'
   workflow_dispatch:
-  push:
-    branches: [master]
 
 concurrency:
   group: folder-images


### PR DESCRIPTION
This causes build failures, because these are usually the "automated
update by adabot", and when the workflow runs the new release has
been created but the metadata is not yet available.

Instead, rely on the cron coming a few hours after adabot so that
the metadata is created & ready.

Typical failure:
```
Requesting redirect information: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/releases/latest
Tag: '20210531'
New version available 20210531.
get bundle metadata from https://adafruit-circuit-python.s3.amazonaws.com/bundles/adafruit/adafruit-circuitpython-bundle-20210531.json
    from get_imports import (
  File "/home/runner/work/Adafruit_CircuitPython_Bundle/Adafruit_CircuitPython_Bundle/CircuitPython_Library_Screenshot_Maker/get_imports.py", line 107, in <module>
    bundle_data = json.load(f)
  File "/opt/hostedtoolcache/Python/3.9.5/x64/lib/python3.9/json/__init__.py", line 293, in load
    return loads(fp.read(),
  File "/opt/hostedtoolcache/Python/3.9.5/x64/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/opt/hostedtoolcache/Python/3.9.5/x64/lib/python3.9/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/opt/hostedtoolcache/Python/3.9.5/x64/lib/python3.9/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```