### PR TITLE
Add MacroPad library to list

### DIFF
--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -31,6 +31,7 @@ specific boards.
     Adafruit CLUE <https://circuitpython.readthedocs.io/projects/clue/en/latest/>
     Adafruit FeatherWings <https://circuitpython.readthedocs.io/projects/featherwing/en/latest/>
     Adafruit FunHouse <https://circuitpython.readthedocs.io/projects/funhouse/en/latest/>
+    Adafruit MacroPad <https://circuitpython.readthedocs.io/projects/macropad/en/latest/>
     MatrixPortal (Metro M4 Airlift + RGB Shield) <https://circuitpython.readthedocs.io/projects/matrixportal/en/latest/>
     Adafruit MagTag <https://circuitpython.readthedocs.io/projects/magtag/en/latest/>
     Adafruit PortalBase <https://circuitpython.readthedocs.io/projects/portalbase/en/latest/>


### PR DESCRIPTION
Looks like most of the list was in alphabetical order, so that's where I put the macropad item.