### PR TITLE
add asyncio

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -866,3 +866,6 @@
 [submodule "libraries/drivers/vl53l1x"]
 	path = libraries/drivers/vl53l1x
 	url = https://github.com/adafruit/Adafruit_CircuitPython_VL53L1X.git
+[submodule "libraries/helpers/asyncio"]
+	path = libraries/helpers/asyncio
+	url = https://github.com/adafruit/Adafruit_CircuitPython_asyncio.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -171,6 +171,7 @@ modules may have a CircuitPython Core API implementation too.
 
 .. toctree::
 
+    asyncio <https://circuitpython.readthedocs.io/projects/asyncio/en/latest/>
     binascii <https://circuitpython.readthedocs.io/projects/binascii/en/latest/>
     datetime <https://circuitpython.readthedocs.io/projects/datetime/en/latest/>
     IterTools <https://circuitpython.readthedocs.io/projects/itertools/en/latest/>


### PR DESCRIPTION
Preliminary version of `asyncio`, adapted from MicroPython version, for use with CircuitPython 7.1.0-beta.0 or later.