### PR TITLE
print GITHUB_CONTEXT without using echo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,9 @@ jobs:
     - name: Dump GitHub context
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
+      run: |
+        export GITHUB_CONTEXT
+        printenv GITHUB_CONTEXT
     - name: Translate Repo Name For Build Tools filename_prefix
       id: repo-name
       run: |


### PR DESCRIPTION
`build.yml` failed because `echo "$GITHUB_CONTEXT"` caused an `argument list too long` error.

Try printing `GITHUB_CONTEXT` with `printenv` instead, to avoid this.