### PR TITLE
update CI Python to 3.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,10 @@ jobs:
         awk -F '\/' '{ print tolower($2) }' |
         tr '_' '-'
         )
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: "3.10"
     - name: Versions
       run: |
         python3 --version

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -26,10 +26,10 @@ jobs:
 
     - name: checkout submodules
       run: git submodule update --init --jobs 16 --depth 1
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: "3.10"
 
     - name: Checkout screenshot maker
       run: git clone --depth=1 https://github.com/circuitpython/CircuitPython_Library_Screenshot_Maker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,10 @@ jobs:
         awk -F '\/' '{ print tolower($2) }' |
         tr '_' '-'
         )
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: "3.10"
     - name: Versions
       run: |
         python3 --version


### PR DESCRIPTION
Recent versions of `circuitpython-build-tools` specified a minimum version of Python 3.7, but 3.6 was specified as the version in the `workflow/*.yml` files. This caused the actions to continue miss recent updates to `circuitpython-build-tools`.

Updated to use Python 3.10. Tried to update to `checkout@v2` also, but that did not work.

Note that the Python version should be in quotes: `"3.10"`. I originally omitted the quotes, and it looked for Python 3.1, because `3.1` was interpreted as a float.

(The build for 20211215 failed last night. I deleted the broken release.)