### PR TITLE
adding 24LC32

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -869,3 +869,6 @@
 [submodule "libraries/helpers/asyncio"]
 	path = libraries/helpers/asyncio
 	url = https://github.com/adafruit/Adafruit_CircuitPython_asyncio.git
+[submodule "libraries/drivers/24lc32"]
+	path = libraries/drivers/24lc32
+	url = https://github.com/adafruit/Adafruit_CircuitPython_24LC32.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -479,6 +479,7 @@ Miscellaneous
 
 .. toctree::
 
+    24LC32 EEPROM <https://circuitpython.readthedocs.io/projects/24lc32/en/latest/>
     74HC595 Shift Register <https://circuitpython.readthedocs.io/projects/74hc595/en/latest/>
     ATECCx08 Cryptographic Co-Processor <https://circuitpython.readthedocs.io/projects/atecc/en/latest/>
     AMG88xx Grid-Eye IR Camera <https://circuitpython.readthedocs.io/projects/amg88xx/en/latest/>


### PR DESCRIPTION
The 24LC32 EEPROM library has it's first official release made now so it can be added to the library bundle.