### PR TITLE
Add ESP32S2TFT to bundle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -875,3 +875,6 @@
 [submodule "libraries/drivers/adxl37x"]
 	path = libraries/drivers/adxl37x
 	url = https://github.com/adafruit/Adafruit_CircuitPython_ADXL37x.git
+[submodule "libraries/helpers/esp32s2tft"]
+	path = libraries/helpers/esp32s2tft
+	url = https://github.com/adafruit/Adafruit_CircuitPython_ESP32S2TFT.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -29,6 +29,7 @@ specific boards.
 
     Adafruit CircuitPlayground <https://circuitpython.readthedocs.io/projects/circuitplayground/en/latest/>
     Adafruit CLUE <https://circuitpython.readthedocs.io/projects/clue/en/latest/>
+    Adafruit ESP32S2TFT <https://circuitpython.readthedocs.io/projects/esp32s2tft/en/latest/>
     Adafruit FeatherWings <https://circuitpython.readthedocs.io/projects/featherwing/en/latest/>
     Adafruit FunHouse <https://circuitpython.readthedocs.io/projects/funhouse/en/latest/>
     Adafruit MacroPad <https://circuitpython.readthedocs.io/projects/macropad/en/latest/>


### PR DESCRIPTION
This is the new ESP32-S2 TFT Feather Portal library.