### PR TITLE
add Adafruit_CircuitPython_HTTPServer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -884,3 +884,6 @@
 [submodule "libraries/drivers/tt21100"]
 	path = libraries/drivers/tt21100
 	url = https://github.com/adafruit/Adafruit_CircuitPython_TT21100.git
+[submodule "libraries/helpers/httpserver"]
+	path = libraries/helpers/httpserver
+	url = https://github.com/adafruit/Adafruit_CircuitPython_HTTPServer.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -117,6 +117,7 @@ Helpers for interfacing with the internet, including IoT protocols.
 .. toctree::
 
     Fake Requests <https://circuitpython.readthedocs.io/projects/fakerequests/en/latest/>
+    HTTP Server <https://circuitpython.readthedocs.io/projects/httpserver/en/latest/>
     JSON Web Token (JWT) <https://circuitpython.readthedocs.io/projects/jwt/en/latest/>
     MiniMQTT <https://circuitpython.readthedocs.io/projects/minimqtt/en/latest/>
     NTP (Network time Protocol) <https://circuitpython.readthedocs.io/projects/ntp/en/latest/>


### PR DESCRIPTION
Adding experimentally; @tannewt has a use case.
API subject to change, and library may be renamed or reworked extensively in the future.