### PR TITLE
remove adafruit_pypixelbuf; use adafruit_pixelbuf only now

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -617,9 +617,6 @@
 [submodule "libraries/drivers/lis3mdl"]
 	path = libraries/drivers/lis3mdl
 	url = https://github.com/adafruit/Adafruit_CircuitPython_LIS3MDL.git
-[submodule "libraries/helpers/pypixelbuf"]
-	path = libraries/helpers/pypixelbuf
-	url = https://github.com/adafruit/Adafruit_CircuitPython_Pypixelbuf.git
 [submodule "libraries/helpers/ble_apple_media"]
 	path = libraries/helpers/ble_apple_media
 	url = https://github.com/adafruit/Adafruit_CircuitPython_BLE_Apple_Media.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -510,7 +510,6 @@ Miscellaneous
     OV5640 Camera <https://circuitpython.readthedocs.io/projects/ov5640/en/latest/>
     OV7670 Camera <https://circuitpython.readthedocs.io/projects/ov7670/en/latest/>
     Pixelbuf <https://circuitpython.readthedocs.io/projects/pixelbuf/en/latest/>
-    PyPixelbuf <https://circuitpython.readthedocs.io/projects/pypixelbuf/en/latest/>
     RockBlock Iridium Satellite Modem <https://circuitpython.readthedocs.io/projects/rockblock/en/latest/>
     Si4713 Stereo FM Transmitter <https://circuitpython.readthedocs.io/projects/si4713/en/latest/>
     Si5351 Clock Generator <https://circuitpython.readthedocs.io/projects/si5351/en/latest/>


### PR DESCRIPTION
As of CircuitPython 7, `adafruit_pixelbuf` is the name used for both the Python library and the native module. Remove `adafruit_pypixelbuf`.