### PR TITLE
print github context in a different way

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Dump GitHub context
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: |
-        export GITHUB_CONTEXT
-        printenv GITHUB_CONTEXT
+      uses: actions/github-script@v6
+      with:
+        script: console.log(JSON.stringify(context, null, 2))
     - name: Translate Repo Name For Build Tools filename_prefix
       id: repo-name
       run: |

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -18,10 +18,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Dump GitHub context
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
-
+      uses: actions/github-script@v6
+      with:
+        script: console.log(JSON.stringify(context, null, 2))
     - uses: actions/checkout@v2.2.0
 
     - name: checkout submodules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Dump GitHub context
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
+      uses: actions/github-script@v6
+      with:
+        script: console.log(JSON.stringify(context, null, 2))
     - name: Translate Repo Name For Build Tools filename_prefix
       id: repo-name
       run: |


### PR DESCRIPTION
In a recent build [with an unusually long change message?] this failed, due to the overall limit on environment variable size in Linux:
```
An error occurred trying to start process '/usr/bin/bash' with working directory '/home/runner/work/Adafruit_CircuitPython_Bundle/Adafruit_CircuitPython_Bundle'. Argument list too long
```

https://github.com/adafruit/Adafruit_CircuitPython_Bundle/actions/runs/2459215636 [link will work for a limited time due to github actions log expiration policy]

The new printed value may not be 100% the same as the old one but it's real close.