### PR TITLE
add adafruit_ticks into drivers.rst

### DIFF
--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -213,6 +213,7 @@ Miscellaneous Helpers
     SimpleMath <https://circuitpython.readthedocs.io/projects/simplemath/en/latest/>
     Test Repo <https://circuitpython.readthedocs.io/projects/testrepo/en/latest/>
     USB HID - Human Interface Device (Keyboard and Mouse) <https://circuitpython.readthedocs.io/projects/hid/en/latest/>
+    Ticks <https://circuitpython.readthedocs.io/projects/ticks/en/latest/>
 
 Blinky
 --------


### PR DESCRIPTION
 Has been added in #331 , but in `drivers.rst` is missing.