### PR TITLE
Add BLE beacon library (now just iBeacon)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -917,3 +917,6 @@
 [submodule "libraries/drivers/pcf8575"]
 	path = libraries/drivers/pcf8575
 	url = https://github.com/adafruit/Adafruit_CircuitPython_PCF8575.git
+[submodule "libraries/helpers/ble_beacon"]
+	path = libraries/helpers/ble_beacon
+	url = https://github.com/adafruit/Adafruit_CircuitPython_BLE_Beacon.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -136,6 +136,7 @@ Helpers for Bluetooth Low Energy (BLE).
     BLE Adafruit Services <https://circuitpython.readthedocs.io/projects/ble_adafruit/en/latest/>
     BLE Apple Media Service <https://circuitpython.readthedocs.io/projects/ble_apple_media/en/latest/>
     BLE Apple Notification Center Service <https://circuitpython.readthedocs.io/projects/ble_apple_notification_center/en/latest/>
+    BLE Location Beacons <https://circuitpython.readthedocs.io/projects/ble_apple_notification_center/en/latest/>
     BLE BerryMed Pulse Oximeter Service <https://circuitpython.readthedocs.io/projects/ble_berrymed_pulse_oximeter/en/latest/>
     BLE BroadcastNet <https://circuitpython.readthedocs.io/projects/ble_broadcastnet/en/latest/>
     BLE Cycling Speed and Cadence <https://circuitpython.readthedocs.io/projects/ble_cycling_speed_and_cadence/en/latest/>


### PR DESCRIPTION
Resolves https://github.com/adafruit/circuitpython/issues/2709 by adding a new library to the bundle!