### PR TITLE
Change Concurrency Group Name

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -6,7 +6,7 @@ name: Generate folder images
 
 on:
   schedule:
-    - cron: '23 22 * * *'
+    - cron: '0 10 * * *'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -6,11 +6,11 @@ name: Generate folder images
 
 on:
   schedule:
-    - cron: '0 10 * * *'
+    - cron: '5 22 * * *'
   workflow_dispatch:
 
 concurrency:
-  group: folder-images
+  group: bundle-folder-images
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -6,7 +6,7 @@ name: Generate folder images
 
 on:
   schedule:
-    - cron: '5 22 * * *'
+    - cron: '23 22 * * *'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
I suspect that the concurrency group name being `folder-images` in both this repos `images.yml` as well as this one over in the Learn repo having the same group name: https://github.com/adafruit/Adafruit_Learning_System_Guides/blob/4aab0129c3fce57580839647b1bd948c185dd13b/.github/workflows/images.yml#L11 is causing these actions runs to get (sort of) cancelled. This page shows the list of supposedly cancelled actions tasks for building the images:
https://github.com/adafruit/Adafruit_CircuitPython_Bundle/actions?query=workflow%3A%22Generate+folder+images%22++

The all report a similar error:
```
update-images
Canceling since a higher priority waiting request for 'folder-images' exists
```
Strangely though they also seem to be completing successfully all of the actual tasks that are in the workflow. The images are getting generated and committed as far as I can tell even though these are indicating cancelled. 

My current working theory is that both this repo and the Learn guide repo have a cron / schedule task that is set to run at the same time `0 10 * * *` and both have the same name `folder-images` so I think these two things trigger at the same time and "cancel each other out" at least some parts of Github are indicating cancelled on them.

I tested this in my own forks of these two repos and found that I was able to get both workflows to run and show successfully when scheduled at the same time by using a different group name for one of them. 

The successful scheduled runs are here:
- https://github.com/FoamyGuy/Adafruit_CircuitPython_Bundle/actions/runs/3162062950
- https://github.com/FoamyGuy/Adafruit_Learning_System_Guides/actions/runs/3162061560

In order to test them without waiting until 10:00 am UTC I temporarily changed the cron times to something different that was a few minutes ahead of the time I made the commits so I could watch them run.

These cancelled runs were discussed on Discord by @jepler, @kattni, and myself on 9/29 https://discord.com/channels/327254708534116352/327298996332658690/1025138001627578469


I can't really rule out some other difference between the adafruit fork and my fork that could be factoring in as well. I was able to get successful runs in my forks. But the true test would be merging this (or a change to the group name in Learn repo) and then waiting until the next day at 10 UTC to see if they show full success.