### PR TITLE
limit image workflow to adafruit fork

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   update-images:
+    if: github.repository_owner == 'adafruit'
     runs-on: ubuntu-20.04
     steps:
     - name: Dump GitHub context


### PR DESCRIPTION
This change restricts the folder-images workflow to only run in repositories under `adafruit` org. 