### PR TITLE
Add BLE File Transfer as a submodule and update drivers.rst

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -920,3 +920,6 @@
 [submodule "libraries/helpers/ble_beacon"]
 	path = libraries/helpers/ble_beacon
 	url = https://github.com/adafruit/Adafruit_CircuitPython_BLE_Beacon.git
+[submodule "libraries/helpers/ble_file_transfer"]
+	path = libraries/helpers/ble_file_transfer
+	url = https://github.com/adafruit/Adafruit_CircuitPython_BLE_File_Transfer.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -147,6 +147,7 @@ Helpers for Bluetooth Low Energy (BLE).
     BLE Magic Light <https://circuitpython.readthedocs.io/projects/ble_magic_light/en/latest/>
     BLE MIDI <https://circuitpython.readthedocs.io/projects/ble_midi/en/latest/>
     BLE Radio <https://circuitpython.readthedocs.io/projects/ble_radio/en/latest/>
+    BLE File Transfer <https://docs.circuitpython.org/projects/ble_file_transfer/en/latest/>
 
 LoRa Wireless Helpers
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -141,13 +141,14 @@ Helpers for Bluetooth Low Energy (BLE).
     BLE BroadcastNet <https://circuitpython.readthedocs.io/projects/ble_broadcastnet/en/latest/>
     BLE Cycling Speed and Cadence <https://circuitpython.readthedocs.io/projects/ble_cycling_speed_and_cadence/en/latest/>
     BLE Eddystone Beacon <https://circuitpython.readthedocs.io/projects/ble_eddystone/en/latest/>
+    BLE File Transfer <https://docs.circuitpython.org/projects/ble_file_transfer/en/latest/>
     BLE Heart Rate <https://circuitpython.readthedocs.io/projects/ble_heart_rate/en/latest/>
     BLE iBBQ <https://circuitpython.readthedocs.io/projects/ble_ibbq/en/latest/>
     BLE LYWSD03MMC (Xiaomi Mijia) <https://circuitpython.readthedocs.io/projects/ble_lywsd03mmc/en/latest/>
     BLE Magic Light <https://circuitpython.readthedocs.io/projects/ble_magic_light/en/latest/>
     BLE MIDI <https://circuitpython.readthedocs.io/projects/ble_midi/en/latest/>
     BLE Radio <https://circuitpython.readthedocs.io/projects/ble_radio/en/latest/>
-    BLE File Transfer <https://docs.circuitpython.org/projects/ble_file_transfer/en/latest/>
+
 
 LoRa Wireless Helpers
 ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR addresses https://github.com/adafruit/Adafruit_CircuitPython_BLE_File_Transfer/issues/15 and adds the BLE File Transfer library to the CircuitPython bundle.

I'm not sure I did this entirely correctly from following the Community Bundle Learn Guide.  If anything needs to be changed or updated, please let me know.

Thanks!