### PR TITLE
Add pixelmap

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -932,3 +932,6 @@
 [submodule "libraries/helpers/displayio_flipclock"]
 	path = libraries/helpers/displayio_flipclock
 	url = https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_FlipClock
+[submodule "libraries/helpers/pixelmap"]
+	path = libraries/helpers/pixelmap
+	url = https://github.com/adafruit/Adafruit_CircuitPython_PixelMap.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -45,6 +45,10 @@ Helper Libraries
 
 These libraries build on top of the low level APIs to simplify common tasks.
 
+.. toctree::
+
+    PixelMap <https://docs.circuitpython.org/projects/pixelmap/en/latest/>
+
 LED Helpers
 ^^^^^^^^^^^^
 
@@ -54,6 +58,7 @@ Helpers for animating LEDs.
 
     Fancy LED (similar to FastLED) <https://docs.circuitpython.org/projects/fancyled/en/latest/>
     LED Animation <https://docs.circuitpython.org/projects/led-animation/en/latest/>
+
 
 User Interface and GFX Helpers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -59,7 +59,6 @@ Helpers for animating LEDs.
     Fancy LED (similar to FastLED) <https://docs.circuitpython.org/projects/fancyled/en/latest/>
     LED Animation <https://docs.circuitpython.org/projects/led-animation/en/latest/>
 
-
 User Interface and GFX Helpers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -45,10 +45,6 @@ Helper Libraries
 
 These libraries build on top of the low level APIs to simplify common tasks.
 
-.. toctree::
-
-    PixelMap <https://docs.circuitpython.org/projects/pixelmap/en/latest/>
-
 LED Helpers
 ^^^^^^^^^^^^
 
@@ -58,6 +54,7 @@ Helpers for animating LEDs.
 
     Fancy LED (similar to FastLED) <https://docs.circuitpython.org/projects/fancyled/en/latest/>
     LED Animation <https://docs.circuitpython.org/projects/led-animation/en/latest/>
+    PixelMap <https://docs.circuitpython.org/projects/pixelmap/en/latest/>
 
 User Interface and GFX Helpers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Adding the new PixelMap library. The core module is merged, but still pending release. The library can be used with latest builds from S3