### PR TITLE
adding GFX library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -935,3 +935,6 @@
 [submodule "libraries/helpers/pixelmap"]
 	path = libraries/helpers/pixelmap
 	url = https://github.com/adafruit/Adafruit_CircuitPython_PixelMap.git
+[submodule "libraries/helpers/gfx"]
+	path = libraries/helpers/gfx
+	url = https://github.com/adafruit/Adafruit_CircuitPython_GFX.git


### PR DESCRIPTION
Solves https://github.com/adafruit/Adafruit_CircuitPython_GFX/issues/27

Note: The library is already in `drivers.rst`