### PR TITLE
adding wii classic to bundle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -944,3 +944,6 @@
 [submodule "libraries/drivers/acep7in"]
 	path = libraries/drivers/acep7in
 	url = https://github.com/adafruit/Adafruit_CircuitPython_ACeP7In.git
+[submodule "libraries/drivers/wii_classic"]
+	path = libraries/drivers/wii_classic
+	url = git@github.com:adafruit/Adafruit_CircuitPython_Wii_Classic.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -544,4 +544,5 @@ Miscellaneous
     TT21100 Capacitive Touchscreen Driver <https://docs.circuitpython.org/projects/tt21100/en/latest/>
     VC0706 TTL Camera <https://docs.circuitpython.org/projects/vc0706/en/latest/>
     VS1053 Audio Codec <https://docs.circuitpython.org/projects/vs1053/en/latest/>
+	Wii Classic <https://docs.circuitpython.org/projects/wii_classic/en/latest/>
     Wiznet5k Ethernet Module <https://docs.circuitpython.org/projects/wiznet5k/en/latest/>


### PR DESCRIPTION
Adding the wii_classic library to the bundle. Allows for interfacing with wii classic controllers over I2C.