### PR TITLE
Adding the AD569x library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -959,3 +959,6 @@
 [submodule "libraries/helpers/json_stream"]
 	path = libraries/helpers/json_stream
 	url = https://github.com/adafruit/Adafruit_CircuitPython_JSON_Stream.git
+[submodule "libraries/drivers/ad569x"]
+	path = libraries/drivers/ad569x
+	url = https://github.com/adafruit/Adafruit_CircuitPython_AD569x.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -481,7 +481,8 @@ These provide functionality similar to ``analogio``, ``digitalio``, ``pulseio``,
 
 .. toctree::
 
-    ADS1x15 Analog-to-Digital Converter  <https://docs.circuitpython.org/projects/ads1x15/en/latest/>
+    AD569x 16-bit DAC <https://docs.circuitpython.org/projects/ad569x/en/latest/>
+	ADS1x15 Analog-to-Digital Converter  <https://docs.circuitpython.org/projects/ads1x15/en/latest/>
     Adafruit SeeSaw <https://docs.circuitpython.org/projects/seesaw/en/latest/>
     AW9523 GPIO expander and LED driver <https://docs.circuitpython.org/projects/aw9523/en/latest/>
     Crickit Robotics Boards <https://docs.circuitpython.org/projects/crickit/en/latest/>


### PR DESCRIPTION
Adding the AD569x library to the bundle (https://github.com/adafruit/Adafruit_CircuitPython_AD569x). just added Adabot as a maintainer on readthedocs so the link is not live yet in `drivers.rst`