### PR TITLE
Adding VCNL4020

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -974,3 +974,9 @@
 [submodule "libraries/drivers/cst8xx"]
 	path = libraries/drivers/cst8xx
 	url = https://github.com/adafruit/Adafruit_CircuitPython_CST8XX.git
+[submodule "libraries/drivers/vcnl4020"]
+	path = libraries/drivers/vcnl4020
+	url = https://github.com/adafruit/Adafruit_CircuitPython_VCNL4020.git
+[submodule "libraries/drivers/libraries/drivers/vcnl4020"]
+	path = libraries/drivers/libraries/drivers/vcnl4020
+	url = https://github.com/adafruit/Adafruit_CircuitPython_VCNL4020.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -975,8 +975,5 @@
 	path = libraries/drivers/cst8xx
 	url = https://github.com/adafruit/Adafruit_CircuitPython_CST8XX.git
 [submodule "libraries/drivers/vcnl4020"]
-	path = libraries/drivers/vcnl4020
-	url = https://github.com/adafruit/Adafruit_CircuitPython_VCNL4020.git
-[submodule "libraries/drivers/libraries/drivers/vcnl4020"]
 	path = libraries/drivers/libraries/drivers/vcnl4020
 	url = https://github.com/adafruit/Adafruit_CircuitPython_VCNL4020.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -437,6 +437,7 @@ These sensors detect light related attributes such as ``color``, ``light`` (unit
     TSL2561 Light Sensor <https://docs.circuitpython.org/projects/tsl2561/en/latest/>
     TSL2591 High Dynamic Range Light Sensor <https://docs.circuitpython.org/projects/tsl2591/en/latest/>
     VCNL4010 Proximity and Light <https://docs.circuitpython.org/projects/vcnl4010/en/latest/>
+    VCNL4020 Proximity and Light <https://docs.circuitpython.org/projects/vcnl4020/en/latest/>
     VCNL4040 Proximity and Light <https://docs.circuitpython.org/projects/vcnl4040/en/latest/>
     VEML6070 UV Index <https://docs.circuitpython.org/projects/veml6070/en/latest/>
     VEML6075 UV Index <https://docs.circuitpython.org/projects/veml6075/en/latest/>


### PR DESCRIPTION
Adding VCNL4020 library to the bundle under drivers. If someone with access to ReadTheDocs is able to accept the adabot invite and add to CircuitPython as a subproject I'd appreciate it