### PR TITLE
Adding ADS7830

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -980,3 +980,6 @@
 [submodule "libraries/helpers/qualia"]
 	path = libraries/helpers/qualia
 	url = https://github.com/adafruit/Adafruit_CircuitPython_Qualia.git
+[submodule "libraries/drivers/ads7830"]
+	path = libraries/drivers/ads7830
+	url = https://github.com/adafruit/Adafruit_CircuitPython_ADS7830.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -485,7 +485,8 @@ These provide functionality similar to ``analogio``, ``digitalio``, ``pulseio``,
 .. toctree::
 
     AD569x 16-bit DAC <https://docs.circuitpython.org/projects/ad569x/en/latest/>
-	ADS1x15 Analog-to-Digital Converter  <https://docs.circuitpython.org/projects/ads1x15/en/latest/>
+    ADS1x15 Analog-to-Digital Converter  <https://docs.circuitpython.org/projects/ads1x15/en/latest/>
+    ADS7830 8-Channel 8-Bit ADC <https://docs.circuitpython.org/projects/ads7830/en/latest/>
     Adafruit SeeSaw <https://docs.circuitpython.org/projects/seesaw/en/latest/>
     AW9523 GPIO expander and LED driver <https://docs.circuitpython.org/projects/aw9523/en/latest/>
     Crickit Robotics Boards <https://docs.circuitpython.org/projects/crickit/en/latest/>

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -485,9 +485,9 @@ These provide functionality similar to ``analogio``, ``digitalio``, ``pulseio``,
 .. toctree::
 
     AD569x 16-bit DAC <https://docs.circuitpython.org/projects/ad569x/en/latest/>
+    Adafruit SeeSaw <https://docs.circuitpython.org/projects/seesaw/en/latest/>
     ADS1x15 Analog-to-Digital Converter  <https://docs.circuitpython.org/projects/ads1x15/en/latest/>
     ADS7830 8-Channel 8-Bit ADC <https://docs.circuitpython.org/projects/ads7830/en/latest/>
-    Adafruit SeeSaw <https://docs.circuitpython.org/projects/seesaw/en/latest/>
     AW9523 GPIO expander and LED driver <https://docs.circuitpython.org/projects/aw9523/en/latest/>
     Crickit Robotics Boards <https://docs.circuitpython.org/projects/crickit/en/latest/>
     CST8XX Capacitive Touch <https://docs.circuitpython.org/projects/cst8xx/en/latest/>


### PR DESCRIPTION
Adding the ADS7830 driver. If someone with access could add it as a subproject to CircuitPython on RTD i'd appreciate it.