### PR TITLE
adding FT5336

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -986,3 +986,6 @@
 [submodule "libraries/helpers/pycamera"]
 	path = libraries/helpers/pycamera
 	url = https://github.com/adafruit/Adafruit_CircuitPython_PyCamera.git
+[submodule "libraries/drivers/ft5336"]
+	path = libraries/drivers/ft5336
+	url = https://github.com/adafruit/Adafruit_CircuitPython_FT5336.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -308,6 +308,7 @@ Other
 .. toctree::
 
     Character LCD <https://docs.circuitpython.org/projects/charlcd/en/latest/>
+    FT5336 Capacitive Touch Screen Driver <https://docs.circuitpython.org/projects/ft5336/en/latest/>
     HT16K33 LED Matrices and Segment Displays <https://docs.circuitpython.org/projects/ht16k33/en/latest/>
     IS31FL3731 Charlieplexed LED Matrix <https://docs.circuitpython.org/projects/is31fl3731/en/latest/>
     IS31FL3741 RGB LED Matrix driver <https://docs.circuitpython.org/projects/is31fl3741/en/latest/>


### PR DESCRIPTION
Adding FT5336 capacitive touch screen driver. If someone with access could add it as a subproject to CircuitPython on RTD i'd appreciate it.