### PR TITLE
adding MCP3421

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -989,3 +989,6 @@
 [submodule "libraries/drivers/ft5336"]
 	path = libraries/drivers/ft5336
 	url = https://github.com/adafruit/Adafruit_CircuitPython_FT5336.git
+[submodule "libraries/drivers/mcp3421"]
+	path = libraries/drivers/mcp3421
+	url = https://github.com/adafruit/Adafruit_CircuitPython_MCP3421.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -498,6 +498,7 @@ These provide functionality similar to ``analogio``, ``digitalio``, ``pulseio``,
     MCP2515 CAN bus controller <https://docs.circuitpython.org/projects/mcp2515/en/latest/>
     MCP230xx GPIO Expander <https://docs.circuitpython.org/projects/mcp230xx/en/latest/>
     MCP3xxx SPI ADC <https://docs.circuitpython.org/projects/mcp3xxx/en/latest/>
+    MCP3421 18-bit ADC <https://docs.circuitpython.org/projects/mcp3421/en/latest/>
     MCP4725 Digital-to-Analog Converter <https://docs.circuitpython.org/projects/mcp4725/en/latest/>
     MCP4728 4-Channel, 12-bit Digital-to-Analog Converter <https://docs.circuitpython.org/projects/mcp4728/en/latest/>
     MPR121 Capacitive Touch Sensor <https://docs.circuitpython.org/projects/mpr121/en/latest/>


### PR DESCRIPTION
Adding MCP3421 ADC driver. If someone with access could add it as a subproject to CircuitPython on RTD i'd appreciate it.