### PR TITLE
adding ADG72x library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -995,3 +995,6 @@
 [submodule "libraries/helpers/connection_manager"]
 	path = libraries/helpers/connection_manager
 	url = https://github.com/adafruit/Adafruit_CircuitPython_ConnectionManager.git
+[submodule "libraries/drivers/adg72x"]
+	path = libraries/drivers/adg72x
+	url = https://github.com/adafruit/Adafruit_CircuitPython_ADG72x.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -489,6 +489,7 @@ These provide functionality similar to ``analogio``, ``digitalio``, ``pulseio``,
 
     AD569x 16-bit DAC <https://docs.circuitpython.org/projects/ad569x/en/latest/>
     Adafruit SeeSaw <https://docs.circuitpython.org/projects/seesaw/en/latest/>
+    ADG72x Analog Matrix Switches <https://docs.circuitpython.org/projects/adg72x/en/latest/>
     ADS1x15 Analog-to-Digital Converter  <https://docs.circuitpython.org/projects/ads1x15/en/latest/>
     ADS7830 8-Channel 8-Bit ADC <https://docs.circuitpython.org/projects/ads7830/en/latest/>
     AW9523 GPIO expander and LED driver <https://docs.circuitpython.org/projects/aw9523/en/latest/>


### PR DESCRIPTION
Adding ADG72x analog matrix switch driver. If someone with access could add it as a subproject to CircuitPython on RTD i'd appreciate it.