### PR TITLE
adding CH9328

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1001,3 +1001,6 @@
 [submodule "libraries/drivers/s35710"]
 	path = libraries/drivers/s35710
 	url = https://github.com/adafruit/Adafruit_CircuitPython_S-35710.git
+[submodule "libraries/drivers/ch9328"]
+	path = libraries/drivers/ch9328
+	url = https://github.com/adafruit/Adafruit_CircuitPython_CH9328.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -527,6 +527,7 @@ Miscellaneous
     AMG88xx Grid-Eye IR Camera <https://docs.circuitpython.org/projects/amg88xx/en/latest/>
     BD3491FS Audio Processor  <https://docs.circuitpython.org/projects/bd3491fs/en/latest/>
     CAP1188 8-Key Capacitive Touch <https://docs.circuitpython.org/projects/cap1188/en/latest/>
+    CH9328 UART to HID Keyboard <https://docs.circuitpython.org/projects/ch9328/en/latest/>
     DRV2605 Haptic Motor Controller <https://docs.circuitpython.org/projects/drv2605/en/latest/>
     DS1841 I2C Logarithmic Potentiometer <https://docs.circuitpython.org/projects/ds1841/en/latest/>
     DS3502 I2C Potentiometer <https://docs.circuitpython.org/projects/ds3502/en/latest/>


### PR DESCRIPTION
Adding CH9328 UART to HID driver. If someone with access could add it as a subproject to CircuitPython on RTD i'd appreciate it.