### PR TITLE
remove hyphen from S-35710

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1000,7 +1000,7 @@
 	url = https://github.com/adafruit/Adafruit_CircuitPython_ADG72x.git
 [submodule "libraries/drivers/s35710"]
 	path = libraries/drivers/s35710
-	url = https://github.com/adafruit/Adafruit_CircuitPython_S-35710.git
+	url = https://github.com/adafruit/Adafruit_CircuitPython_S35710.git
 [submodule "libraries/drivers/ch9328"]
 	path = libraries/drivers/ch9328
 	url = https://github.com/adafruit/Adafruit_CircuitPython_CH9328.git


### PR DESCRIPTION
The "official" repo URL seems to be without the hyphen, however Github seems to do some automatic redirecting so both URLs work as long as the client will follow the redirect:

https://github.com/adafruit/Adafruit_CircuitPython_S-35710.git
https://github.com/adafruit/Adafruit_CircuitPython_S35710.git

I think that the hyphen being in the name here in gitmodules is making the code that generates the library infrascruture report for circuitpython.org/contributing include this library as "not in bundle" even though it is in the bundle. 

I'm hoping that this change will make it so it no longer appears in that list.
