### PR TITLE
add sphinx config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
     - id: black
 -   repo: https://github.com/fsfe/reuse-tool
-    rev: v0.12.1
+    rev: v1.1.2
     hooks:
     - id: reuse
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,9 @@
 # Required
 version: 2
 
+sphinx:
+  configuration: docs/conf.py
+
 build:
   os: ubuntu-22.04
   tools:


### PR DESCRIPTION
RTD is deprecating the default configuration, and it must be specified in the yaml file moving forward https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

This adds the configuration to the yaml file in this repo. 

Also updated re-use to a newer version which matches the one used currently by library repos, and is able to run under python 3.12