### PR TITLE
adding lps28

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1052,3 +1052,6 @@
 [submodule "libraries/drivers/gc9a01a"]
 	path = libraries/drivers/gc9a01a
 	url = https://github.com/adafruit/Adafruit_CircuitPython_GC9A01A.git
+[submodule "libraries/drivers/lps28"]
+	path = libraries/drivers/lps28
+	url = https://github.com/adafruit/Adafruit_CircuitPython_LPS28.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -402,6 +402,7 @@ equivalent carbon dioxide (``eco2`` / ``eCO2``), and total volatile organic comp
     HTU21D Temperature and Humidity (adafruit_htu21d) <https://docs.circuitpython.org/projects/htu21d/en/latest/>
     HTU31D Temperature and Humidity (adafruit_htu31d) <https://docs.circuitpython.org/projects/htu31d/en/latest/>
     LPS2X Family of Barometric Pressure, Temperature Sensors (adafruit_lps2x) <https://docs.circuitpython.org/projects/lps2x/en/latest/>
+    LPS28 Pressure Sensor (adafruit_lps28) <https://docs.circuitpython.org/projects/lps28/en/latest/>
     LPS35HW Water Resistant Barometric Pressure, Temperature (adafruit_lps35hw) <https://docs.circuitpython.org/projects/lps35hw/en/latest/>
     SGP40 Air Quality Sensor (adafruit_sgp40) <https://docs.circuitpython.org/projects/sgp40/en/latest/>
     MAX31855 Thermocouple Amplifier, Temperature (adafruit_max31855) <https://docs.circuitpython.org/projects/max31855/en/latest/>


### PR DESCRIPTION
adding LPS28 pressure sensor library. this needs to be added to the circuitpython subproject on readthedocs as well