### PR TITLE
update workflow to run on ubuntu 24.04

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   update-images:
     if: github.repository_owner == 'adafruit'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
" The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Ubuntu 20.04. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times: " -- email