### PR TITLE
adding adafruit_pathlib

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1070,3 +1070,6 @@
 [submodule "libraries/helpers/anchored_group"]
 	path = libraries/helpers/anchored_group
 	url = https://github.com/adafruit/Adafruit_CircuitPython_Anchored_Group.git
+[submodule "libraries/helpers/pathlib"]
+	path = libraries/helpers/pathlib
+	url = https://github.com/adafruit/Adafruit_CircuitPython_Pathlib.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -190,6 +190,7 @@ modules may have a CircuitPython Core API implementation too.
     binascii (adafruit_binascii) <https://docs.circuitpython.org/projects/binascii/en/latest/>
     datetime (adafruit_datetime) <https://docs.circuitpython.org/projects/datetime/en/latest/>
     IterTools (adafruit_itertools) <https://docs.circuitpython.org/projects/itertools/en/latest/>
+    pathlib (adafruit_pathlib) <https://docs.circuitpython.org/projects/pathlib/en/latest/>
     Logging  (adafruit_logging) <https://docs.circuitpython.org/projects/logging/en/latest/>
     hashlib (adafruit_hashlib) <https://docs.circuitpython.org/projects/hashlib/en/latest/>
 


### PR DESCRIPTION
Has already been added as a subproject to circuitpython on RTD.