### PR TITLE
update python version used by actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
         awk -F '\/' '{ print tolower($2) }' |
         tr '_' '-'
         )" >> $GITHUB_OUTPUT
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Versions
       run: |
         python3 --version

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -22,10 +22,10 @@ jobs:
 
     - name: checkout submodules
       run: git submodule update --init --jobs 16 --depth 1
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.12"
 
     - name: Checkout screenshot maker
       run: git clone --depth=1 https://github.com/circuitpython/CircuitPython_Library_Screenshot_Maker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,10 @@ jobs:
         awk -F '\/' '{ print tolower($2) }' |
         tr '_' '-'
         )" >> $GITHUB_OUTPUT
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Versions
       run: |
         python3 --version


### PR DESCRIPTION
The generate images has been failing due to the new usb host mouse library: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/actions/runs/14969427865

This change updates the actions from this repo to use python 3.12, essentially the same fix that was applied to the workflows from each library repo here: https://github.com/adafruit/workflows-circuitpython-libs/pull/38

I think only the images one needs to be updated to fix the specific actions failure linked, but it makes sense to me to keep them all in sync. 

resolves: https://github.com/adafruit/Adafruit_CircuitPython_USB_Host_Mouse/issues/3