### PR TITLE
adding INA23x

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1091,3 +1091,6 @@
 [submodule "libraries/drivers/sen6x"]
 	path = libraries/drivers/sen6x
 	url = https://github.com/adafruit/Adafruit_CircuitPython_SEN6x.git
+[submodule "libraries/drivers/ina23x"]
+	path = libraries/drivers/ina23x
+	url = https://github.com/adafruit/Adafruit_CircuitPython_INA23x.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -560,6 +560,7 @@ Miscellaneous
     HUSB238 (adafruit_husb238) <https://docs.circuitpython.org/projects/husb238/en/latest/>
     INA219 High Side Current (adafruit_ina219) <https://docs.circuitpython.org/projects/ina219/en/latest/>
     INA228 High or Low Side Power Monitor (adafruit_ina228) <https://docs.circuitpython.org/projects/ina228/en/latest/>
+    INA23x Current and Power Monitor (adafruit_ina23x) <https://docs.circuitpython.org/projects/ina23x/en/latest/>
     INA260 Current and Power Monitor (adafruit_ina260) <https://docs.circuitpython.org/projects/ina260/en/latest/>
     INA3221 Three Channel Amp Power Monitor (adafruit_ina3221) <https://docs.circuitpython.org/projects/ina3221/en/latest/>
     LC709203F Fuel Gauge and Battery Monitor (adafruit_lc709203f) <https://docs.circuitpython.org/projects/lc709203f/en/latest/>


### PR DESCRIPTION
Adding INA23x driver. This needs to be added to the circuitpython subproject on readthedocs please