### PR TITLE
adding bmp5xx

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1118,3 +1118,6 @@
 [submodule "libraries/drivers/mlx90632"]
 	path = libraries/drivers/mlx90632
 	url = https://github.com/adafruit/Adafruit_CircuitPython_MLX90632.git
+[submodule "libraries/drivers/bmp5xx"]
+	path = libraries/drivers/bmp5xx
+	url = https://github.com/adafruit/Adafruit_CircuitPython_BMP5xx.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -403,6 +403,7 @@ equivalent carbon dioxide (``eco2`` / ``eCO2``), and total volatile organic comp
     BME680 Temperature, Humidity, Pressure and Gas (adafruit_bme680) <https://docs.circuitpython.org/projects/bme680/en/latest/>
     BMP280 Barometric Pressure and Altitude (adafruit_bmp280) <https://docs.circuitpython.org/projects/bmp280/en/latest/>
     BMP3xx Barometric Pressure and Altimeter (adafruit_bmp3xx) <https://docs.circuitpython.org/projects/bmp3xx/en/latest/>
+    BMP5xx Barometric Pressure and Altimeter (adafruit_bmp5xx) <https://docs.circuitpython.org/projects/bmp5xx/en/latest/>
     CCS811 Air Quality (adafruit_ccs811) <https://docs.circuitpython.org/projects/ccs811/en/latest/>
     DHT Temperature and Humidity (adafruit_dht) <https://docs.circuitpython.org/projects/dht/en/latest/>
     DPS310 Precision Barometric Pressure / Altitude Sensor (adafruit_dps310) <https://docs.circuitpython.org/projects/dps310/en/latest/>


### PR DESCRIPTION
bmp5xx is already added as a subproject on RTD.

I accidentally committed this to `main` at first, but reverted that and created this PR as was the intent. 