### PR TITLE
adding jd79667

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1130,3 +1130,6 @@
 [submodule "libraries/drivers/pcm51xx"]
 	path = libraries/drivers/pcm51xx
 	url = https://github.com/adafruit/Adafruit_CircuitPython_PCM51xx.git
+[submodule "libraries/driver/jd79667"]
+	path = libraries/driver/jd79667
+	url = https://github.com/adafruit/Adafruit_CircuitPython_JD79667.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -311,6 +311,7 @@ E-Paper / E-Ink
     IL0398 (displayio) (adafruit_il0398) <https://docs.circuitpython.org/projects/il0398/en/latest/>
     IL91874 (displayio) (adafruit_il91874) <https://docs.circuitpython.org/projects/il91874/en/latest/>
     JD79661 (displayio) (adafruit_jd79661) <https://docs.circuitpython.org/projects/jd79661/en/latest/>
+    JD79667 (displayio) (adafruit_jd79667) <https://docs.circuitpython.org/projects/jd79667/en/latest/>
     SPD1656 (displayio) (adafruit_spd1656) <https://docs.circuitpython.org/projects/spd1656/en/latest/>
     SSD1608 (displayio) (adafruit_ssd1608) <https://docs.circuitpython.org/projects/ssd1608/en/latest/>
     SSD1675 (displayio) (adafruit_ssd1675) <https://docs.circuitpython.org/projects/ssd1675/en/latest/>


### PR DESCRIPTION
Adding JD79667 driver. This needs to be added to the circuitpython subproject on readthedocs please