### PR TITLE
adding AY8912 emulator helper library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1181,3 +1181,6 @@
 [submodule "libraries/drivers/max44009"]
 	path = libraries/drivers/max44009
 	url = https://github.com/adafruit/Adafruit_CircuitPython_MAX44009.git
+[submodule "libraries/helpers/ay8912"]
+	path = libraries/helpers/ay8912
+	url = https://github.com/adafruit/Adafruit_CircuitPython_AY8912.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -205,6 +205,7 @@ Music, noisemakers, and more.
 
 .. toctree::
 
+    AY8912 Emulator (adafruit_ay8912) <https://docs.circuitpython.org/projects/ay8912/en/latest/>
     MIDI (adafruit_midi) <https://docs.circuitpython.org/projects/midi/en/latest/>
     Ring Tone Text Transfer Language (RTTTL) (adafruit_rtttl) <https://docs.circuitpython.org/projects/rtttl/en/latest/>
     Waveform Generation (adafruit_waveform) <https://docs.circuitpython.org/projects/waveform/en/latest/>


### PR DESCRIPTION
adding AY8912 emulator helper library. this also needs to be added to the circuitpython subproject on readthedocs please