### PR TITLE
adding ADS7128

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1184,3 +1184,6 @@
 [submodule "libraries/helpers/ay8912"]
 	path = libraries/helpers/ay8912
 	url = https://github.com/adafruit/Adafruit_CircuitPython_AY8912.git
+[submodule "libraries/drivers/ads7128"]
+	path = libraries/drivers/ads7128
+	url = https://github.com/adafruit/Adafruit_CircuitPython_ADS7128.git

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -536,6 +536,7 @@ These provide functionality similar to ``analogio``, ``digitalio``, ``pulseio``,
     ADG72x Analog Matrix Switches (adafruit_adg72x) <https://docs.circuitpython.org/projects/adg72x/en/latest/>
     ADS1x15 Analog-to-Digital Converter  (adafruit_ads1x15) <https://docs.circuitpython.org/projects/ads1x15/en/latest/>
     ADS122C04 24-Bit ADC (adafruit_ads122c04) <https://docs.circuitpython.org/projects/ads122c04/en/latest/>
+    ADS7128 8-Channel ADC and GPIO Expander (adafruit_ads7128) <https://docs.circuitpython.org/projects/ads7128/en/latest/>
     ADS7830 8-Channel 8-Bit ADC (adafruit_ads7830) <https://docs.circuitpython.org/projects/ads7830/en/latest/>
     AW9523 GPIO expander and LED driver (adafruit_aw9523) <https://docs.circuitpython.org/projects/aw9523/en/latest/>
     Crickit Robotics Boards (adafruit_crickit) <https://docs.circuitpython.org/projects/crickit/en/latest/>


### PR DESCRIPTION
adding ADS7128 adc/gpio expander driver. this also needs to be added to the circuitpython subproject on readthedocs please